### PR TITLE
Use Emacs `straight.el` instead of `package.el`.

### DIFF
--- a/.chezmoiexternal.toml
+++ b/.chezmoiexternal.toml
@@ -1,4 +1,0 @@
-[".config/emacs/site-lisp/mood-line"]
-    type = "git-repo"
-    url = "https://gitlab.com/dylangleason/mood-line.git"
-    refreshPeriod = "168h"

--- a/dot_config/emacs/early-init.el
+++ b/dot_config/emacs/early-init.el
@@ -9,3 +9,7 @@
     (funcall mode -1)))
 
 (setq inhibit-startup-message t)
+
+;; disable package.el since we'll be using straight.el
+(when (version<= "26" emacs-version)
+  (setq package-enable-at-startup nil))

--- a/dot_config/emacs/init.el
+++ b/dot_config/emacs/init.el
@@ -42,22 +42,27 @@
 
 (global-set-key (kbd "C-c C-c") 'comment-or-uncomment-region)
 
-;;; Initialize packages
+;;; Manage packages using straight.el instead of package.el
 
-(package-initialize)
+(defvar bootstrap-version)
+(let ((bootstrap-file
+       (expand-file-name "straight/repos/straight.el/bootstrap.el" user-emacs-directory))
+      (bootstrap-version 6))
+  (unless (file-exists-p bootstrap-file)
+    (with-current-buffer
+        (url-retrieve-synchronously
+         "https://raw.githubusercontent.com/radian-software/straight.el/develop/install.el"
+         'silent 'inhibit-cookies)
+      (goto-char (point-max))
+      (eval-print-last-sexp)))
+  (load bootstrap-file nil 'nomessage))
 
-(unless (package-installed-p 'use-package)
-  (package-refresh-contents)
-  (package-install 'use-package))
-
-(eval-when-compile
-  (require 'use-package)
-  (setq use-package-always-defer t)
-  (setq use-package-always-ensure t))
-
-(add-to-list 'load-path (concat user-emacs-directory "lisp"))
+(setq straight-use-package-by-default t)
+(straight-use-package 'use-package)
 
 ;;; Require additional elisp packages in the lisp directory
+
+(add-to-list 'load-path (concat user-emacs-directory "lisp"))
 
 (cl-loop for file in (directory-files (concat user-emacs-directory "lisp"))
 	 and prev = nil then file

--- a/dot_config/emacs/lisp/init-base.el
+++ b/dot_config/emacs/lisp/init-base.el
@@ -15,7 +15,6 @@
    ("C-c C-;" . embark-dwim)))
 
 (use-package evil
-  :after undo-tree
   :demand t
   :init
   (setq evil-want-integration t
@@ -63,8 +62,6 @@
   (marginalia-mode))
 
 (use-package mood-line
-  :load-path "site-lisp/mood-line"
-  :demand t
   :config
   (mood-line-mode))
 
@@ -90,7 +87,9 @@
 (use-package projectile-ripgrep
   :after (projectile ripgrep))
 
-(use-package rainbow-delimiters)
+(use-package rainbow-delimiters
+  :hook
+  (prog-mode . rainbow-delimiters-mode))
 
 (use-package restclient
   :demand t
@@ -98,6 +97,15 @@
   (add-to-list 'auto-mode-alist '("\\.http\\'" . restclient-mode)))
 
 (use-package ripgrep)
+
+(use-package tree-sitter
+  :hook
+  (tree-sitter-after-on . tree-sitter-hl-mode)
+  :init
+  (global-tree-sitter-mode))
+
+(use-package tree-sitter-langs
+  :after (tree-sitter))
 
 (use-package undo-tree
   :init
@@ -109,8 +117,11 @@
 
 (use-package vertico-buffer
   :after vertico
-  :ensure nil
+  :straight nil
   :init
+  ;; NOTE: straight does not automatically export this extension into
+  ;; the main repo directory. Must manually copy from
+  ;; `extensions/vertico-buffer.el` to parent repo directory.
   (vertico-buffer-mode))
 
 (use-package vterm

--- a/dot_config/emacs/lisp/init-c-cpp.el
+++ b/dot_config/emacs/lisp/init-c-cpp.el
@@ -24,11 +24,11 @@
   (setq-local compile-command "dmd"))
 
 (use-package c-mode
-  :ensure nil
+  :straight nil
   :hook (c-mode . my-c-mode-hook))
 
 (use-package c++-mode
-  :ensure nil
+  :straight nil
   :hook (c++-mode . my-c++-mode-hook))
 
 (use-package company-dcd

--- a/dot_config/emacs/lisp/init-go.el
+++ b/dot_config/emacs/lisp/init-go.el
@@ -1,7 +1,6 @@
 ;;; -*- lexical-binding: t -*-
 
 (defun my-go-mode-hook ()
-  (rainbow-delimiters-mode-enable)
   (flycheck-mode)
   (setq lsp-go-env '((GOFLAGS . "--tags=wireinject")))
   (lsp-deferred))
@@ -13,7 +12,7 @@
 	flycheck-gometalinter-vendor t
 	flycheck-gometalinter-enable-linters '("golint"))
   :config
-  (flycheck-go-metalinter-setup))
+  (flycheck-gometalinter-setup))
 
 (use-package go-mode
   :hook

--- a/dot_config/emacs/lisp/init-lisp.el
+++ b/dot_config/emacs/lisp/init-lisp.el
@@ -1,39 +1,35 @@
 ;;; -*- lexical-binding: t -*-
 
-(defun my-lisp-mode-common-hook ()
-  (enable-paredit-mode)
-  (rainbow-delimiters-mode-enable))
-
 (use-package cider
   :hook
-  ((cider-mode . my-lisp-mode-common-hook)
+  ((cider-mode . enable-paredit-mode)
    (cider-repl-mode . (lambda ()
-			(my-lisp-mode-common-hook)
+			(enable-paredit-mode)
 			(local-set-key (kbd "C-c C-b") 'cider-repl-clear-buffer))))
   :config
   (add-to-list 'evil-emacs-state-modes 'cider-repl-mode)
   (add-to-list 'evil-emacs-state-modes 'cider-stacktrace-mode))
 
 (use-package clojure-mode
-  :hook (clojure-mode . my-lisp-mode-common-hook))
+  :hook (clojure-mode . enable-paredit-mode))
 
 (use-package emacs-lisp-mode
-  :ensure nil
-  :hook (emacs-lisp-mode . my-lisp-mode-common-hook))
+  :straight nil
+  :hook (emacs-lisp-mode . enable-paredit-mode))
 
 (use-package geiser-guile
-  :hook (geiser-repl-mode . my-lisp-mode-common-hook))
+  :hook (geiser-repl-mode . enable-paredit-mode))
 
 (use-package paredit
   :bind (:map paredit-mode-map ("RET" . nil)))
 
 (use-package scheme-mode
-  :ensure nil
-  :hook (scheme-mode . my-lisp-mode-common-hook))
+  :straight nil
+  :hook (scheme-mode . enable-paredit-mode))
 
 (use-package slime
-  :hook ((slime-mode . my-lisp-mode-common-hook)
-         (slime-repl-mode . my-lisp-mode-common-hook))
+  :hook ((slime-mode . enable-paredit-mode)
+         (slime-repl-mode . enable-paredit-mode))
   :init
   (setq inferior-lisp-program "sbcl"
         slime-protocol-version 'ignore)

--- a/dot_config/emacs/lisp/init-python.el
+++ b/dot_config/emacs/lisp/init-python.el
@@ -16,7 +16,7 @@
 		   (lsp-deferred))))
 
 (use-package python
-  :ensure nil
+  :straight nil
   :hook
   (python-mode . flycheck-mode)
   :init

--- a/dot_config/emacs/lisp/init-ruby.el
+++ b/dot_config/emacs/lisp/init-ruby.el
@@ -25,7 +25,7 @@
   (advice-add 'rubocop-build-command :override #'my-rubocop-build-command))
 
 (use-package ruby-mode
-  :ensure nil
+  :straight nil
   :mode "\\(?:\\.rb\\|ru\\|rake\\|thor\\|jbuilder\\|gemspec\\|podspec\\|/\\(?:Gem\\|Rake|Cap\\|Thor\\|Vagrant\\|Guard\\|Pod\\)file\\)\\'"
   :hook (ruby-mode . my-ruby-mode-hook)
   :interpreter "ruby")


### PR DESCRIPTION
Implement the following Emacs configuration improvements:

- Use `straight.el` instead of `package.el` for managing packages.
- Use `tree-sitter` for improved syntax highlighting.
- Configure `rainbow-delimiters` for all prog modes.
- Fix function call to `flycheck-gometalinter-setup`.
- Remove custom `mood-line` fork as evil mode supported in trunk.